### PR TITLE
Closing the root listener closes child listeners

### DIFF
--- a/cmux_test.go
+++ b/cmux_test.go
@@ -169,15 +169,13 @@ func TestErrorHandler(t *testing.T) {
 	}
 }
 
-type closerConn struct {
-	net.Conn
-}
+func TestClose(t *testing.T) {
+	l, _ := testListener(t)
 
-func (c closerConn) Close() error { return nil }
+	muxl := New(l)
+	anyl := muxl.Match(Any())
 
-func TestClosed(t *testing.T) {
-	mux := &cMux{}
-	lis := mux.Match(Any()).(muxListener)
-	close(lis.donec)
-	mux.serve(closerConn{})
+	l.Close()
+	muxl.Serve()
+	anyl.Accept()
 }


### PR DESCRIPTION
Partially reverts b90740dfa9b286c06f58fa798929e2d2cb1299e5; the same
protection is now afforded by an RWMutex which protects the channels
while they are being served on.