### PR TITLE
rely on project to call flag.Parse rather than when used as library

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -1,7 +1,6 @@
 package cmux
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"net"
@@ -40,10 +39,6 @@ var (
 
 // New instantiates a new connection multiplexer.
 func New(l net.Listener) CMux {
-	if !flag.Parsed() {
-		flag.Parse()
-	}
-
 	return &cMux{
 		root:   l,
 		bufLen: 1024,


### PR DESCRIPTION
I believe that it should be up to the package to call flag.Parse() rather than the library. This renders the library unusable for projects that rely on implementations of flag other than in go's standard library.

I am having a hard time tracking down why this is necessary. It looks like the http2 library only uses flags in its main packages.