### PR TITLE
Reduce the number of calls needed to (*MuxConn).Read

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -7,19 +7,27 @@ type buffer struct {
 	data []byte
 }
 
-func (b *buffer) Read(p []byte) (n int, err error) {
-	n = len(b.data) - b.read
-	if n == 0 {
-		return 0, io.EOF
-	}
-
-	if len(p) < n {
-		n = len(p)
-	}
-
-	copy(p[:n], b.data[b.read:b.read+n])
+// From the io.Reader documentation:
+//
+// When Read encounters an error or end-of-file condition after
+// successfully reading n > 0 bytes, it returns the number of
+// bytes read.  It may return the (non-nil) error from the same call
+// or return the error (and n == 0) from a subsequent call.
+// An instance of this general case is that a Reader returning
+// a non-zero number of bytes at the end of the input stream may
+// return either err == EOF or err == nil.  The next Read should
+// return 0, EOF.
+//
+// This function implements the latter behaviour, returning the
+// (non-nil) error from the same call.
+func (b *buffer) Read(p []byte) (int, error) {
+	var err error
+	n := copy(p, b.data[b.read:])
 	b.read += n
-	return
+	if b.read == len(b.data) {
+		err = io.EOF
+	}
+	return n, err
 }
 
 func (b *buffer) Len() int {

--- a/cmux.go
+++ b/cmux.go
@@ -174,13 +174,26 @@ func newMuxConn(c net.Conn) *MuxConn {
 	}
 }
 
-func (m *MuxConn) Read(b []byte) (n int, err error) {
-	if n, err = m.buf.Read(b); err == nil {
-		return
+// From the io.Reader documentation:
+//
+// When Read encounters an error or end-of-file condition after
+// successfully reading n > 0 bytes, it returns the number of
+// bytes read.  It may return the (non-nil) error from the same call
+// or return the error (and n == 0) from a subsequent call.
+// An instance of this general case is that a Reader returning
+// a non-zero number of bytes at the end of the input stream may
+// return either err == EOF or err == nil.  The next Read should
+// return 0, EOF.
+//
+// This function implements the latter behaviour, returning the
+// (non-nil) error from the same call.
+func (m *MuxConn) Read(b []byte) (int, error) {
+	n1, err := m.buf.Read(b)
+	if n1 == len(b) || err != io.EOF {
+		return n1, err
 	}
-
-	n, err = m.Conn.Read(b)
-	return
+	n2, err := m.Conn.Read(b[n1:])
+	return n1 + n2, err
 }
 
 func (m *MuxConn) sniffer() io.Reader {


### PR DESCRIPTION
Also affects (*buffer).Read.