### PR TITLE
Tweak shutdown behaviour (again)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -32,7 +32,6 @@ func BenchmarkCMuxConn(b *testing.B) {
 		}
 	}()
 
-	donec := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(b.N)
 
@@ -41,6 +40,6 @@ func BenchmarkCMuxConn(b *testing.B) {
 		c := &mockConn{
 			r: bytes.NewReader(benchHTTPPayload),
 		}
-		m.serve(c, donec, &wg)
+		m.serve(c, &wg)
 	}
 }


### PR DESCRIPTION
The previous behaviour was unsound, as it was prone to dropping
connections under (temporary) high load. The new behaviour requires that
users are well-behaved with respect to shutdown - the root listener
must be shut down before any of the child listeners are, otherwise
deadlocks may occur. This requirement seems reasonable.