### PR TITLE
(*MuxConn).Read: fix erroneous io.EOF return

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -199,12 +199,12 @@ func newMuxConn(c net.Conn) *MuxConn {
 //
 // This function implements the latter behaviour, returning the
 // (non-nil) error from the same call.
-func (m *MuxConn) Read(b []byte) (int, error) {
-	n1, err := m.buf.Read(b)
-	if n1 == len(b) || err != io.EOF {
+func (m *MuxConn) Read(p []byte) (int, error) {
+	n1, err := m.buf.Read(p)
+	if err != io.EOF {
 		return n1, err
 	}
-	n2, err := m.Conn.Read(b[n1:])
+	n2, err := m.Conn.Read(p[n1:])
 	return n1 + n2, err
 }
 


### PR DESCRIPTION
This fixes a bug where (*MuxConn).Read would return io.EOF if the
buffer was exactly the right size to fill the passed-in slice.