### PR TITLE
SetReadDeadline for Matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - 1.5
   - 1.6
+  - 1.7
   - tip
 
 matrix:

--- a/bench_test.go
+++ b/bench_test.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/http2"
 )
@@ -41,6 +42,10 @@ type mockConn struct {
 
 func (c *mockConn) Read(b []byte) (n int, err error) {
 	return c.r.Read(b)
+}
+
+func (c *mockConn) SetReadDeadline(time.Time) error {
+	return nil
 }
 
 func discard(l net.Listener) {


### PR DESCRIPTION
this timeout allows clients which don't send any data to match cmux.Any()

also unused connections get closed after a while