### PR TITLE
Add matchers for header value prefixes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -112,7 +112,7 @@ func Example() {
 
 	// We first match the connection against HTTP2 fields. If matched, the
 	// connection will be sent through the "grpcl" listener.
-	grpcl := m.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
+	grpcl := m.Match(cmux.HTTP2HeaderFieldPrefix("content-type", "application/grpc"))
 	//Otherwise, we match it againts a websocket upgrade request.
 	wsl := m.Match(cmux.HTTP1HeaderField("Upgrade", "websocket"))
 


### PR DESCRIPTION
This adds matchers to check the prefix of a header value instead of equality with a header value. This is so that correct matching of the gRPC `content-type` header can be done - note that per https://grpc.io/docs/guides/wire.html, `application/grpc` is just the prefix, and an encoding type can be added afterwards. This is something I am working on in https://github.com/grpc/grpc-go/pull/1203 and will have a new PR that implements this per the discussion on that PR soon.