### PR TITLE
Increase test timeout from 100ms to 500ms

### DIFF
--- a/cmux_test.go
+++ b/cmux_test.go
@@ -253,7 +253,7 @@ func TestTimeout(t *testing.T) {
 	lis, Close := testListener(t)
 	defer Close()
 	result := make(chan int, 5)
-	testDuration := time.Millisecond * 100
+	testDuration := time.Millisecond * 500
 	m := New(lis)
 	m.SetReadTimeout(testDuration)
 	http1 := m.Match(HTTP1Fast())


### PR DESCRIPTION
This is re: the failure on https://github.com/soheilhy/cmux/pull/50. My general rule is 5x for travis, a nicer solution is to have a multiple controlled by an environment variable for testing, and to set it to 5 for Travis, but this will help for now.