### PR TITLE
Fix TestClose for Go10.

### DIFF
--- a/cmux_test.go
+++ b/cmux_test.go
@@ -659,7 +659,9 @@ func TestClose(t *testing.T) {
 		if err != ErrListenerClosed {
 			t.Fatal(err)
 		}
-		if _, err := c2.Read([]byte{}); err != io.ErrClosedPipe {
+		// The error is either io.ErrClosedPipe or net.OpError wrapping
+		// a net.pipeError depending on the go version.
+		if _, err := c2.Read([]byte{}); !strings.Contains(err.Error(), "closed") {
 			t.Fatalf("connection is not closed and is leaked: %v", err)
 		}
 	}

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -81,7 +81,7 @@ func (l *chanListener) Accept() (net.Conn, error) {
 }
 
 func testListener(t *testing.T) (net.Listener, func()) {
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Depending on the Go version used, reading from a closed pipe can return
net.OpError or io.ErrClosedPipe. Simply check the string content of the
error.