### PR TITLE
Fix bug matchers are ignored except last one

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -115,10 +115,10 @@ type cMux struct {
 
 func matchersToMatchWriters(matchers []Matcher) []MatchWriter {
 	mws := make([]MatchWriter, 0, len(matchers))
-	for _, _m := range matchers {
-		m := _m
+	for _, m := range matchers {
+		cm := m
 		mws = append(mws, func(w io.Writer, r io.Reader) bool {
-			return m(r)
+			return cm(r)
 		})
 	}
 	return mws

--- a/cmux.go
+++ b/cmux.go
@@ -115,7 +115,8 @@ type cMux struct {
 
 func matchersToMatchWriters(matchers []Matcher) []MatchWriter {
 	mws := make([]MatchWriter, 0, len(matchers))
-	for _, m := range matchers {
+	for _, _m := range matchers {
+		m := _m
 		mws = append(mws, func(w io.Writer, r io.Reader) bool {
 			return m(r)
 		})


### PR DESCRIPTION
On the current code, only last matcher specified by `Match()` is used and others are ignored.