### PR TITLE
Add CMux.Close() to shutdown server

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -199,7 +199,7 @@ func (m *cMux) serve(c net.Conn, donec <-chan struct{}, wg *sync.WaitGroup) {
 				}
 				select {
 				case sl.l.connc <- muc:
-				case <-m.donec:
+				case <-donec:
 					_ = c.Close()
 				}
 				return

--- a/example_test.go
+++ b/example_test.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/net/websocket"
 
 	"github.com/soheilhy/cmux"
+	"google.golang.org/grpc/examples/helloworld/helloworld"
 	grpchello "google.golang.org/grpc/examples/helloworld/helloworld"
 )
 
@@ -86,7 +87,9 @@ func serveRPC(l net.Listener) {
 	}
 }
 
-type grpcServer struct{}
+type grpcServer struct {
+	helloworld.UnimplementedGreeterServer
+}
 
 func (s *grpcServer) SayHello(ctx context.Context, in *grpchello.HelloRequest) (
 	*grpchello.HelloReply, error) {


### PR DESCRIPTION
We don't have a nice way to close CMux server. This PR adds a Close method that tries to gracefully stop cmux server.

Related issue: https://github.com/soheilhy/cmux/issues/39