### PR TITLE
remove support for deprecated tls.VersionSSL30

### DIFF
--- a/matchers.go
+++ b/matchers.go
@@ -71,7 +71,6 @@ func HTTP1Fast(extMethods ...string) Matcher {
 func TLS(versions ...int) Matcher {
 	if len(versions) == 0 {
 		versions = []int{
-			tls.VersionSSL30,
 			tls.VersionTLS10,
 			tls.VersionTLS11,
 			tls.VersionTLS12,


### PR DESCRIPTION
The Go authors deprecated support for SSLv3 in go 1.13. They've decided to remove it in go 1.14, and have already merged the commit. 

See: https://golang.org/issue/32716

This PR, or something like it, should probably land before February 2020.