### PR TITLE
update travis-ci test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.6
-  - 1.7
-  - 1.8
+  - 1.13
   - tip
 
 matrix:


### PR DESCRIPTION
This PR reconfigures Travis to stop attempting to build on Go versions 1.6, 1.7, and 1.8.