### PR TITLE
do not propagate "use of closed conn" error if expected

### DIFF
--- a/cmux.go
+++ b/cmux.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 )
@@ -169,6 +170,14 @@ func (m *cMux) Serve() error {
 	for {
 		c, err := m.root.Accept()
 		if err != nil {
+			if strings.Contains(err.Error(), "use of closed network connection") {
+				select {
+				case <-m.donec: // error is expected
+					return nil
+				default:
+				}
+			}
+
 			if !m.handleErr(err) {
 				return err
 			}

--- a/cmux_test.go
+++ b/cmux_test.go
@@ -47,7 +47,7 @@ const (
 )
 
 func safeServe(errCh chan<- error, muxl CMux) {
-	if err := muxl.Serve(); !strings.Contains(err.Error(), "use of closed") {
+	if err := muxl.Serve(); err != nil && !strings.Contains(err.Error(), "use of closed") {
 		errCh <- err
 	}
 }


### PR DESCRIPTION
There's unfortunately no way (AFAIK) of actively interrupting a
`net.Listener.Accept()` call, so we have to deal with it erroring out if/when
its net.Listener is closed (see #39).

Unfortunately(2) there's also no better way of matching the low-level
error than string checks, since it is not exported by the stdlib.

